### PR TITLE
Add max name length, add green background to current player

### DIFF
--- a/src/assets/stylesheets/_players.scss
+++ b/src/assets/stylesheets/_players.scss
@@ -27,14 +27,6 @@
   justify-content: space-evenly;
   max-height: 150px;
   margin-bottom: 0;
-
-  .player-info {
-    max-width: 50%;
-    p {
-      overflow: hidden;
-      max-width: 50%;
-    }
-  }
 }
 
 #players {
@@ -82,13 +74,14 @@ input {
   p {
     display: flex;
     align-items: center;
-    margin-left: 5px;
     margin-bottom: 5px;
+    max-width: 200px;
+    overflow: hidden;
   }
 }
 
-.highlighted {
-  border: 2px solid magenta!important;
+.player-card.highlighted {
+  background-color: #06D6A0;
 }
 
 .player-lives {

--- a/src/assets/stylesheets/_startup.scss
+++ b/src/assets/stylesheets/_startup.scss
@@ -31,7 +31,7 @@ section h2 {
   background-color: $default-color;
   cursor: pointer;
   transition: color ease 0.3s;
-font-size: $icon-width / 4;
+  font-size: $icon-width / 4;
 }
 
 .btn i {
@@ -125,7 +125,7 @@ font-size: $icon-width / 4;
       cursor: pointer;
     }
     p {
-      max-width: 50%;
+      max-width: 100%;
       overflow: hidden;
     }
   }

--- a/src/modules/domController.js
+++ b/src/modules/domController.js
@@ -93,6 +93,14 @@ function _checkFormValidity (event, playerList, newPlayer) {
     return false
   }
 
+  if (newPlayer.name.length > 16) {
+    PubSub.publish(TOPIC.SEND_LOG, {
+      type: 4,
+      message: 'The max name length is 16 characters.'
+    })
+    return false
+  }
+
   if (!event.target.elements.playerName.validity.valid) {
     PubSub.publish(TOPIC.SEND_LOG, {
       type: 4,


### PR DESCRIPTION
I added a check on the playerName to set a max length of 16 characters, and added an error message to the game log. I also changed the .highlighted CSS class to make the background green instead of a pink border.

I kept the overflow: hidden on the 'p' elements... Longer names still don't look great. I experimented with wrapping text or smaller font sizes, but I'm still not sure what to do about it.