### PR TITLE
Change game log position, fix hearts display, add play again button

### DIFF
--- a/src/assets/stylesheets/_log.scss
+++ b/src/assets/stylesheets/_log.scss
@@ -1,6 +1,6 @@
 #log { 
   position: fixed;
-  bottom: 0;
+  top: 0;
   z-index: 1;
   width: 50%;
   font-size: 1.25rem;
@@ -8,9 +8,9 @@
   padding: 20px;
   border-radius: 10px;
   box-shadow: -4px 5px grey;
-  margin-bottom: 3rem;
+  margin-top: 120px;
   
-  background-color: rgba(255, 228, 196, 0.801);
+  background-color: rgba(255, 228, 196, 0.9);
 
   &[data-type="success"] {
     box-shadow: -4px 5px green;

--- a/src/assets/stylesheets/_log.scss
+++ b/src/assets/stylesheets/_log.scss
@@ -5,6 +5,10 @@
   width: 50%;
   font-size: 1.25rem;
 
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
   padding: 20px;
   border-radius: 10px;
   box-shadow: -4px 5px grey;
@@ -12,19 +16,45 @@
   
   background-color: rgba(255, 228, 196, 0.9);
 
-  &[data-type="success"] {
-    box-shadow: -4px 5px green;
+  &[data-type="success"],
+  &[data-type="gameover"] {
+    box-shadow: -4px 5px #06D6A0;
   }
 
   &[data-type="warning"] {
-    box-shadow: -4px 5px yellow;
+    box-shadow: -4px 5px #FCBF49;
   }
 
   &[data-type="error"] {
-    box-shadow: -4px 5px red;
+    box-shadow: -4px 5px #f94144;
   }
 
   &:hover {
     cursor: pointer;
+  }
+
+  &.cursor-normal:hover {
+    cursor: default;
+  }
+
+  button {
+    border: none;
+    background: none;
+    outline: none;
+    text-align: center;
+    font-size: inherit;
+  }
+
+  a {
+    text-decoration: none;
+    color: #000300;
+    padding: 0.8rem 0.8rem;
+    transition: color 0.3s ease-in-out, background-color 0.3s ease-in-out;
+    border-radius: 0.5rem;
+
+    &:hover {
+      color: #fff;
+      background-color: #000300;
+    }
   }
 }

--- a/src/modules/Game.js
+++ b/src/modules/Game.js
@@ -62,7 +62,7 @@ export const Game = (() => {
     }
 
     if (playerTurn.ai) {
-      setTimeout(() => callAi(), 1100)
+      setTimeout(() => callAi(), 2000)
     }
   }
 

--- a/src/modules/GameActions.js
+++ b/src/modules/GameActions.js
@@ -18,18 +18,16 @@ export const GameActions = (() => {
     while (nextCard.hasPlayer()) {
       let opponent = nextCard.getPlayer()
       opponent = getPlayerById(Game.players, opponent.id)
-      if (opponent.finish_line > 0) {
-        opponent.finish_line -= 1
-        PubSub.publish(TOPIC.UPDATE_FINISH_LINE, opponent)
-      }
+      Game.getPlayerTurn().finish_line += opponent.finish_line
+      PubSub.publish(TOPIC.UPDATE_FINISH_LINE, Game.getPlayerTurn())
+      opponent.finish_line = 0
+      PubSub.publish(TOPIC.UPDATE_FINISH_LINE, opponent)
 
       PubSub.publish(TOPIC.SEND_LOG, {
         type: 2,
         message: `${Game.getPlayerTurn().name} jumped over ${opponent.name} and stole their hearts!`
       })
 
-      Game.getPlayerTurn().finish_line += 1
-      PubSub.publish(TOPIC.UPDATE_FINISH_LINE, Game.getPlayerTurn())
       if (nextCard.hasPlayer() && opponent.id == Game.getPlayerTurn().id) break
       if (nextCard.hasPlayer()) {
         nextCardPosition = getNextCardPosition(nextCardPosition)

--- a/src/modules/GameActions.js
+++ b/src/modules/GameActions.js
@@ -76,7 +76,7 @@ export const GameActions = (() => {
       )
     PubSub.publish(TOPIC.WON_THE_GAME, {winner})
     PubSub.publish(TOPIC.SEND_LOG, {
-      type: 2,
+      type: 5,
       message: `${winner.name} wins the game!`
     })
   }

--- a/src/modules/GameLog.js
+++ b/src/modules/GameLog.js
@@ -8,9 +8,19 @@ const _createLogDOMElement = () => {
   return element
 }
 
+function _clickToHide() {
+  this.classList.add('hidden')
+}
 
-function _clickToHide(logDOM) {
-  logDOM.addEventListener('click', () => logDOM.classList.add('hidden'))
+function _showPlayAgainButton(logDOM) {
+  let playAgainLink = document.createElement("a")
+  playAgainLink.textContent = 'Play Again?'
+  playAgainLink.href = "/"
+
+  let playAgainButton = document.createElement("button")
+
+  playAgainButton.appendChild(playAgainLink)
+  logDOM.appendChild(playAgainLink)
 }
 
 const logDOM = _createLogDOMElement()
@@ -23,8 +33,16 @@ function sendLogMessage(logDOM, type, message) {
   logDOM.setAttribute("data-type", type)
   logDOM.setAttribute("id", 'log')
   logDOM.textContent = message
+
+  if (type === "gameover") {
+    _showPlayAgainButton(logDOM)
+    logDOM.removeEventListener('click', _clickToHide)
+    logDOM.classList.add('cursor-normal')
+    return
+  }
+
   let pendingLog = setTimeout(() => logDOM.classList.add("hidden"), 4000)
-  _clickToHide(logDOM, pendingLog)
+  logDOM.addEventListener('click', _clickToHide)
   pendingLogs.push(pendingLog)
 }
 
@@ -49,6 +67,8 @@ function convertTypeToStringType(type_num) {
       return 'warning'
     case 4:
       return 'error'
+    case 5:
+      return 'gameover'
   }
   return 'info'
 }

--- a/src/modules/domController.js
+++ b/src/modules/domController.js
@@ -237,7 +237,7 @@ PubSub.subscribe(TOPIC.SHOW_ICON_CHOICES, showIconChoices)
 const cardList = document.getElementById('card-list')
 const playerDisplay = document.getElementById('player-display');
 
-function _createPlayerDisplayDOM (player) {
+function _createPlayerDisplayDOM (player, playerList) {
   let playerCard = createElement('div', 'player-card', playerDisplay)
   playerCard.setAttribute('data-id', player.id)
 
@@ -245,7 +245,7 @@ function _createPlayerDisplayDOM (player) {
   let playerName = createElement('p', null)
   let playerIcon = createElement('img', null)
   let playerLives = createElement('div', 'player-lives')
-  _createPlayerLivesDOM(playerLives)
+  _createPlayerLivesDOM(playerLives, playerList)
 
   playerIcon.src = player.iconSrc
   playerName.textContent = player.name
@@ -258,18 +258,13 @@ function _createPlayerDisplayDOM (player) {
   playerCard.appendChild(playerInfo)
 }
 
-function _createPlayerLivesDOM (playerLives) {
-  let lifeOne = createElement('i', 'life fas fa-heart', playerLives)
-  let lifeTwo = createElement('i', 'life fas fa-heart', playerLives)
-  let lifeThree = createElement('i', 'life fas fa-heart', playerLives)
-  let lifeFour = createElement('i', 'life fas fa-heart', playerLives)
+function _createPlayerLivesDOM (playerLives, playerList) {
+  for (let i = 1; i <= playerList.length; i++) {
+    let lifeDOM = createElement('i', 'life fas fa-heart', playerLives)
+    lifeDOM.setAttribute('data-id', i)
+  }
 
-  lifeOne.setAttribute('data-id', 1)
-  lifeTwo.setAttribute('data-id', 2)
-  lifeThree.setAttribute('data-id', 3)
-  lifeFour.setAttribute('data-id', 4)
-
-  lifeOne.classList.add('filled')
+  playerLives.querySelector("[data-id='1']").classList.add('filled')
 }
 
 function _removePlayerHighlights(playerList) {
@@ -300,7 +295,7 @@ function highlightPlayerTurn (topic, data) {
 
 function createPlayerDisplay (topic, playerList) {
   playerList.forEach(player => {
-    _createPlayerDisplayDOM(player)
+    _createPlayerDisplayDOM(player, playerList)
   })
 }
 

--- a/src/modules/memoryCardController.js
+++ b/src/modules/memoryCardController.js
@@ -68,7 +68,7 @@ function init (playerList) {
     StaticCardList.moveToEndIfReach(cardPlayerDOM)
   }, 300)
 
-  Game.callAi()
+  setTimeout(() => Game.callAi(), 2000)
 }
 
 export { init, getNextCardPosition, getNextPlayerPosition }


### PR DESCRIPTION
I make a few tweaks to the game in this PR:

* Move the game log from the bottom of the screen towards the top, so it doesn't cover the flippable cards
* Fix player display so it only shows as many hearts as there are players
* Fix finish_line logic to match the game rules -> when a player jumps over another player, they steal ALL lives instead of just one
* Add a "Play Again?" button in the game log after someone wins the game
* Increase the setTimout interval for callAI() so that the bots take a little bit more time between moves